### PR TITLE
move frame configuration at the task's toplevel

### DIFF
--- a/orientationTypes.hpp
+++ b/orientationTypes.hpp
@@ -22,10 +22,6 @@ namespace orientation_estimator
     /** Filter Configuration **/
     struct FilterConfiguration
     {
-        std::string source_frame_name; //Output Frame name. Transformation: source -> target
-
-        std::string target_frame_name; //Output Frame name. Transformation: source -> target
-
         bool use_samples_as_theoretical_gravity;//Inclinometers are more stable than accelerometers at initial time.
                                                     //They cloud be use as theoretical local gravity value instead of using
                                                     //some models as WGS-84 ellipsoid Earth.

--- a/orientation_estimator.orogen
+++ b/orientation_estimator.orogen
@@ -154,6 +154,9 @@ task_context 'IKF' do
         max_latency(0.05)
     end
 
+    # The frame exported as target frame in the generated orientations
+    property 'world_frame', '/std/string'
+
     #******************************
     #******* Output Ports *********
     #******************************

--- a/tasks/IKF.cpp
+++ b/tasks/IKF.cpp
@@ -315,8 +315,8 @@ bool IKF::configureHook()
 
     /** Output variable **/
     orientation_out.invalidate();
-    orientation_out.sourceFrame = config.source_frame_name;
-    orientation_out.targetFrame = config.target_frame_name;
+    orientation_out.sourceFrame = _body_frame.get();
+    orientation_out.targetFrame = _world_frame.get();
     orientation_out.orientation.setIdentity();
     acc_body = Eigen::Vector3d::Ones() * base::NaN<double>();
 


### PR DESCRIPTION
Unless I am mistaken, the body frame and output's source frame
are required to be the same. Moreover, the convention for frame
configuration (as done in the transformer) is to have a property
called <framename>_frame, e.g. here world_frame. This convention
is required by e.g. Syskit for the transformer configuration
