### PR TITLE
create addHeadingOffset

### DIFF
--- a/orientation_estimator.orogen
+++ b/orientation_estimator.orogen
@@ -184,7 +184,7 @@ task_context 'IKF' do
     #********* Operations *********
     #******************************
 
-    # Resets the current heading, usually to the true north
+    # Resets the current heading, usually to the true north, and reinitializes the filter state.
     #
     # For the purpose of aligning the heading to an absolute heading (e.g. true
     # north), addHeadingOffset should be preferred. This is kept for
@@ -193,14 +193,15 @@ task_context 'IKF' do
         returns('bool').
         argument('heading', 'double', 'heading')
 
-    # Add an offset to the current heading
+    # Add an offset to the current heading and reinitialize the filter state.
     #
     # This is commonly used to align the heading estimate to the true north. It
     # should be preferred to resetHeading as the offset is a constant, whereas
     # resetting to an absolute heading is time-sensitive.
     operation('addHeadingOffset').
         returns('bool').
-        argument('heading', 'double', 'heading')
+        argument('heading', 'double', 'heading').
+        argument('variance', 'double', 'Initial variance of the new heading state in rad/s^2')
 
     #******************************
     #********** States ************

--- a/orientation_estimator.orogen
+++ b/orientation_estimator.orogen
@@ -91,10 +91,24 @@ task_context 'BaseEstimator' do
     #******************************
     #********* Operations *********
     #******************************
+
+    # Resets the current heading, usually to the true north
+    #
+    # For the purpose of aligning the heading to an absolute heading (e.g. true
+    # north), addHeadingOffset should be preferred. This is kept for
+    # backward-compatibility
     operation('resetHeading').
         returns('bool').
         argument('heading', 'double', 'heading').
         doc 'resets the current heading, optimally to the true north'
+
+    # Add an offset to the current heading
+    #
+    # This is commonly used to align the heading estimate to the true north. It
+    # should be preferred to resetHeading as the offset is a constant, whereas
+    # resetting to an absolute heading is time-sensitive.
+    operation('addHeadingOffset').
+        argument('offset', 'double', 'heading')
 
     port_driven
 end
@@ -169,10 +183,24 @@ task_context 'IKF' do
     #******************************
     #********* Operations *********
     #******************************
+
+    # Resets the current heading, usually to the true north
+    #
+    # For the purpose of aligning the heading to an absolute heading (e.g. true
+    # north), addHeadingOffset should be preferred. This is kept for
+    # backward-compatibility
     operation('resetHeading').
         returns('bool').
-        argument('heading', 'double', 'heading').
-        doc 'resets the current heading, optimally to the true north'
+        argument('heading', 'double', 'heading')
+
+    # Add an offset to the current heading
+    #
+    # This is commonly used to align the heading estimate to the true north. It
+    # should be preferred to resetHeading as the offset is a constant, whereas
+    # resetting to an absolute heading is time-sensitive.
+    operation('addHeadingOffset').
+        returns('bool').
+        argument('heading', 'double', 'heading')
 
     #******************************
     #********** States ************

--- a/tasks/BaseEstimator.cpp
+++ b/tasks/BaseEstimator.cpp
@@ -268,6 +268,15 @@ bool BaseEstimator::resetHeading(double heading)
     return true;
 }
 
+void BaseEstimator::addHeadingOffset(double offset)
+{
+    (*euler)[2]    += offset;
+    (*oldeuler)[2] += offset;
+    (*head_q) = Eigen::Quaternion <double> (Eigen::AngleAxisd((*euler)[2], Eigen::Vector3d::UnitZ())*
+			Eigen::AngleAxisd((*euler)[1], Eigen::Vector3d::UnitY()) *
+			Eigen::AngleAxisd((*euler)[0], Eigen::Vector3d::UnitX()));
+}
+
 
 /**
  * @brief This function computes the discrete-time propagation of a quaternion

--- a/tasks/BaseEstimator.hpp
+++ b/tasks/BaseEstimator.hpp
@@ -53,6 +53,7 @@ namespace orientation_estimator {
         virtual void imu_orientationCallback(const base::Time &ts, const ::base::samples::RigidBodyState &imu_orientation_sample);
 	
 	virtual bool resetHeading(double heading);
+        virtual void addHeadingOffset(double offset);
 
     public:
 	EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/tasks/IKF.cpp
+++ b/tasks/IKF.cpp
@@ -594,9 +594,12 @@ void IKF::initializeFilter(const Eigen::Quaterniond& attitude, const Eigen::Matr
     /** Initial error covariance **/
     P_0 = Eigen::Matrix <double,IKFSTATEVECTORSIZE,IKFSTATEVECTORSIZE>::Zero();
     P_0.block <3, 3> (0,0) = cov_attitude;//Error quaternion
-    P_0.block <3, 3> (3,3) = 1.0e-06 * Eigen::Matrix3d::Identity();//Gyros bias
-    P_0.block <3, 3> (6,6) = 1.0e-06 * Eigen::Matrix3d::Identity();//Accelerometers bias
-    P_0.block <3, 3> (9,9) = 1.0e-06 * Eigen::Matrix3d::Identity();//Inclinometers bias
+    P_0.block <3, 3> (3,3) = Qbg;//Gyros bias
+    P_0.block <3, 3> (6,6) = Qba;//Accelerometers bias
+    if(config.use_inclinometers)
+        P_0.block <3, 3> (9,9) = Qbi;//Inclinometers bias
+    else
+        P_0.block <3, 3> (9,9) = 1.0e-06 * Eigen::Matrix3d::Identity();//Inclinometers bias
 
     /** Theoretical Gravity **/
     double gravity = GRAVITY;

--- a/tasks/IKF.cpp
+++ b/tasks/IKF.cpp
@@ -202,6 +202,7 @@ bool IKF::configureHook()
     /***********************/
     initializeFilter(Eigen::Quaterniond::Identity(), 1.e-06 * Eigen::Matrix3d::Identity());
 
+    /** Set constant noise of forwarded acc and gyro measurements */
     double sqrtdelta_t = sqrt(1.0/accnoise.bandwidth); /** Noise depends on frequency bandwidth **/
     acceleration_out.cov_acceleration = Eigen::Matrix3d::Zero(); // this is the noise on the acceleration output which occurs at every sample
     acceleration_out.cov_acceleration(0,0) = accnoise.resolution[0] + pow(accnoise.randomwalk[0]/sqrtdelta_t,2);
@@ -209,6 +210,10 @@ bool IKF::configureHook()
     acceleration_out.cov_acceleration(2,2) = accnoise.resolution[2] + pow(accnoise.randomwalk[2]/sqrtdelta_t,2);
 
     sqrtdelta_t = sqrt(1.0/gyronoise.bandwidth); /** Noise depends on frequency bandwidth **/
+    cov_angular_velocity = Eigen::Matrix3d::Zero();
+    cov_angular_velocity(0,0) = pow(gyronoise.randomwalk[0]/sqrtdelta_t,2);
+    cov_angular_velocity(1,1) = pow(gyronoise.randomwalk[1]/sqrtdelta_t,2);
+    cov_angular_velocity(2,2) = pow(gyronoise.randomwalk[2]/sqrtdelta_t,2);
 
     /** Alignment configuration **/
     initial_alignment.acc.setZero();
@@ -472,6 +477,7 @@ void IKF::writeOutput(IKFFilter & filter)
             }
         }
 	orientation_out.angular_velocity = current_angular_velocity;
+        orientation_out.cov_angular_velocity = cov_angular_velocity;
 
         _orientation_samples_out.write(orientation_out);
 

--- a/tasks/IKF.cpp
+++ b/tasks/IKF.cpp
@@ -585,3 +585,12 @@ bool IKF::resetHeading(double heading)
                                             Eigen::AngleAxisd(euler[2], Eigen::Vector3d::UnitX());
     return ikf_filter.setAttitude(corrected_attitide);
 }
+
+bool IKF::addHeadingOffset(double offset)
+{
+    base::Vector3d euler = base::getEuler(ikf_filter.getAttitude());
+    Eigen::Quaterniond corrected_attitide = Eigen::AngleAxisd(euler[0] + offset, Eigen::Vector3d::UnitZ()) *
+                                            Eigen::AngleAxisd(euler[1], Eigen::Vector3d::UnitY()) *
+                                            Eigen::AngleAxisd(euler[2], Eigen::Vector3d::UnitX());
+    return ikf_filter.setAttitude(corrected_attitide);
+}

--- a/tasks/IKF.hpp
+++ b/tasks/IKF.hpp
@@ -130,7 +130,9 @@ namespace orientation_estimator {
         void initialAlignment(const base::Time &ts, const base::samples::IMUSensors &imu_sample);
 
         virtual bool resetHeading(double heading);
-        virtual bool addHeadingOffset(double offset);
+        virtual bool addHeadingOffset(double offset, double variance);
+
+        void initializeFilter(const Eigen::Quaterniond& attitude, const Eigen::Matrix3d& cov_attitude);
 
     public:
         /** TaskContext constructor for IKF

--- a/tasks/IKF.hpp
+++ b/tasks/IKF.hpp
@@ -130,6 +130,7 @@ namespace orientation_estimator {
         void initialAlignment(const base::Time &ts, const base::samples::IMUSensors &imu_sample);
 
         virtual bool resetHeading(double heading);
+        virtual bool addHeadingOffset(double offset);
 
     public:
         /** TaskContext constructor for IKF

--- a/tasks/IKF.hpp
+++ b/tasks/IKF.hpp
@@ -100,6 +100,8 @@ namespace orientation_estimator {
 
         Eigen::Vector3d acc_body; // saved acceleration for output
 
+        Eigen::Matrix3d cov_angular_velocity;
+
         /** Accumulated measurement for attitude calculation */
         base::samples::IMUSensors initial_alignment;
 


### PR DESCRIPTION
For the use-case of aligning the estimator to e.g. a true north,
resetHeading is heavily latency-sensitive, while addHeadingOffset
is latency-independent (the offset is either constant or slow-
changing)